### PR TITLE
Look for LilyPond in /Applications/LilyPond.app/Contents/Resources/bin on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Spontini-Editor's text editor component uses **[Codemirror](https://codemirror.n
 
 Thanks to [Aaron Hill](https://github.com/seraku24), Thomas Morley, Martin Tarenskeen and the #regex, #javascript and #python irc channels (freenode) for the support in doing this!
 
-## 
+##
 ![img](documentation/images/intro.gif)
 <br></br><br></br>
 # INSTALLATION
@@ -43,47 +43,43 @@ Thanks to [Aaron Hill](https://github.com/seraku24), Thomas Morley, Martin Taren
   **1) Install [LilyPond with version >= 2.19.84 (included) and <= 2.22.0 (included)](http://lilypond.org/unix.html)**
 
   **2) Install [Python 3.6 or newer](https://www.python.org/downloads/source)**
-    
+
     *On Debian based distros (Ubuntu, Mint etc.) just use:*
 
     ``` sudo apt install python3 python3-tk python3-pip python3-venv ```
-    
+
 <br></br>
 * ### **WINDOWS**
 
   **1) Install [LilyPond with version >= 2.19.84 (included) and <= 2.22.0 (included)](http://lilypond.org/windows.html)**
 
   **2) Install [Python 3.6 or newer](https://www.python.org/downloads/windows)**
-  
+
 <br></br>
 * ### **MACOSX**
 
   **1) Install [LilyPond with version >= 2.19.84 (included) and <= 2.22.0 (included)](http://lilypond.org/macos-x.html)**
 
-    If you installed an unofficial 64-bit application bundle (macOS >= 10.15.0) you need to add LilyPond to your PATH: 
-    
-    ``` export PATH="${PATH}:/Applications/LilyPond.app/Contents/Resources/bin" ``` 
-
-  **2) Install [Python 3.6 or newer](https://www.python.org/downloads/mac-osx)**    
+  **2) Install [Python 3.6 or newer](https://www.python.org/downloads/mac-osx)**
 
 <br></br>
 # QUICK START
 
   **1)** Copy the Spontini-Editor directory wherever you want, run **SpontiniServer.py** with Python 3 and wait until the setup has been completed.
-    
+
   **2)** Open the page: ***http://localhost:8000/spontini-editor*** with your browser. The editor will appear and it will allow to edit and compile files in the default workspace, which is the "examples" directory of the project.
 
   <br></br>
   **IMPORTANT NOTE!** *Keep ALL the files in the main directory at their place, otherwise SpontiniServer.py won't work*.
-  
+
   **NOTE** for **Windows** users: *you can launch SpontiniServer by simply double-clicking on SpontiniServer-WIN.vbs (or SpontiniServer-WIN.bat).*
 
-  **NOTE** for **macOS** users: *you can launch SpontiniServer by right-clicking on the file and then choose "Open with" ---> "Python launcher". 
+  **NOTE** for **macOS** users: *you can launch SpontiniServer by right-clicking on the file and then choose "Open with" ---> "Python launcher".
     Make sure that Python launcher is configured for running python 3, as the following image shows:*
-    
+
   ![img](documentation/images/pylauncher.png)
-  
-  
+
+
 <br></br>
 # [GO TO THE DOCUMENTATION](documentation/toc.md)
 <br></br>

--- a/lib/python/spontini_server_core.py
+++ b/lib/python/spontini_server_core.py
@@ -23,6 +23,7 @@ import os
 import glob
 import shutil
 import pathlib
+import platform
 import subprocess
 from subprocess import PIPE
 import xml.etree.ElementTree as ET
@@ -45,7 +46,7 @@ wsDirPath = ""
 currDirAbsolutePath = pathlib.Path(".").resolve()
 httpd = None
 lilyExecutableCmd = ""
-lilyExecName = "lilypond-windows.exe" if os.name == "nt" else "lilypond"
+lilyExecName = "lilypond-windows.exe" if platform.system() == "Windows" else "lilypond"
 debug = True
 venvedPyCmd = ""
 venvedExecDir = ""
@@ -191,8 +192,7 @@ def getDefaultLilyExecutableCmd():
 
   if checkLilyExecutable(lilyExecName):
     ret = lilyExecName
-
-  elif os.name == "nt":
+  elif platform.system() == 'Windows':
     programFilesEnv = os.environ.get('ProgramFiles', 'C:\\Program Files')
     log("Could not find default Lilypond installation in sys path", "I")
     log("Checking default Lilypond installation in " + programFilesEnv + " path", "I")
@@ -211,6 +211,10 @@ def getDefaultLilyExecutableCmd():
       log("Found executable: \"" + ret + "\"", "I")
       if not checkLilyExecutable(ret):
         ret = ""
+  elif platform.system() == 'Darwin':
+    path = os.path.join('/Applications', 'LilyPond.app','Contents', 'Resources', 'bin', 'lilypond')
+    if os.path.exists(path):
+      ret = path
 
   if ret == "":
     log("Could not find default valid Lilypond installation!", "E")


### PR DESCRIPTION
Following up on [this Reddit thread](https://www.reddit.com/r/lilypond/comments/l0uzfo/spontinieditor_an_advanced_gui_assistant_for/gkq0ppd?utm_source=share&utm_medium=web2x&context=3).

Here is the resulting log:

```
2021-01-26 08:28:00 [I] Checking default Lilypond installation in sys path
2021-01-26 08:28:00 [I] Checking if "lilypond" is a valid Lilypond executable
2021-01-26 08:28:00 [I] Traceback (most recent call last):
  File "/Users/alexis/src/Spontini/lib/python/spontini_server_core.py", line 175, in checkLilyExecutable
    p = subprocess.run([execCmd, "--version"], encoding='utf-8')
  File "/usr/local/Cellar/python@3.9/3.9.1_6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 501, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/local/Cellar/python@3.9/3.9.1_6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 947, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/local/Cellar/python@3.9/3.9.1_6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 1819, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'lilypond'

2021-01-26 08:28:00 [I] "lilypond" is not a valid Lilypond executable
2021-01-26 08:28:00 [S] Found default valid Lilypond installation
2021-01-26 08:28:00 [I] 
2021-01-26 08:28:00 [I] ***********************************
2021-01-26 08:28:00 [I] ***********************************
2021-01-26 08:28:00 [I] 
2021-01-26 08:28:00 [I] -- Version: 0.7
2021-01-26 08:28:00 [I] -- Workspace: /Users/alexis/src/Spontini/examples
2021-01-26 08:28:00 [I] -- Lilypond executable: /Applications/LilyPond.app/Contents/Resources/bin/lilypond
2021-01-26 08:28:00 [I] -- Pip3 found
2021-01-26 08:28:00 [I] -- Python virtual env found/set
2021-01-26 08:28:00 [I] -- cairosvg disabled
2021-01-26 08:28:00 [I] -- Running in virtual env: spontinivenv
2021-01-26 08:28:00 [I] 
2021-01-26 08:28:00 [I] Spontini Server initialized
```